### PR TITLE
Bug Fixes (#4585)

### DIFF
--- a/Data/Regions.xml
+++ b/Data/Regions.xml
@@ -2445,10 +2445,6 @@
       <rect x="1698" y="1567" width="5" height="60" />
       <rect x="1687" y="1627" width="26" height="26" />
     </region>
-	<region priority="50" name="Gravewater Lake">
-			<rect x="1440" y="1527" width="423" height="219" />
-			<rect x="1381" y="1565" width="215" height="224" />
-	</region>
     <region type="MondainRegion" priority="50" name="Gravewater Dock">
       <rect x="1692" y="1551" width="16" height="16" />
     </region>

--- a/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
@@ -1,10 +1,12 @@
 using System;
 
+using Server.Engines.Craft;
+
 namespace Server.Items
 {
-    public class SummonersKilt : GargishClothKilt
+    public class SummonersKilt : GargishClothKilt, IRepairable
 	{
-		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTailoring.CraftSystem; } }
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
 		
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113540; } } // Summoner's Kilt

--- a/Scripts/Items/Consumables/OrangePetals.cs
+++ b/Scripts/Items/Consumables/OrangePetals.cs
@@ -41,7 +41,7 @@ namespace Server.Items
         {
             get
             {
-                return 0.1;
+                return Core.HS ? 1.0 : 0.1;
             }
         }
         public static void RemoveContext(Mobile m)

--- a/Scripts/Items/Equipment/Clothing/Shoes.cs
+++ b/Scripts/Items/Equipment/Clothing/Shoes.cs
@@ -111,7 +111,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [Flipable(0x2307, 0x2308)]
     public class FurBoots : BaseShoes
     {
@@ -148,7 +148,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [FlipableAttribute(0x170b, 0x170c)]
     public class Boots : BaseShoes
     {
@@ -193,7 +193,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [Flipable]
     public class ThighBoots : BaseShoes, IArcaneEquip
     {
@@ -346,7 +346,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [FlipableAttribute(0x170f, 0x1710)]
     public class Shoes : BaseShoes
     {
@@ -391,7 +391,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [FlipableAttribute(0x170d, 0x170e)]
     public class Sandals : BaseShoes
     {
@@ -446,7 +446,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [Flipable(0x2797, 0x27E2)]
     public class NinjaTabi : BaseShoes
     {
@@ -483,7 +483,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [Flipable(0x2796, 0x27E1)]
     public class SamuraiTabi : BaseShoes
     {
@@ -520,7 +520,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [Flipable(0x2796, 0x27E1)]
     public class Waraji : BaseShoes
     {
@@ -557,7 +557,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     [FlipableAttribute(0x2FC4, 0x317A)]
     public class ElvenBoots : BaseShoes
     {
@@ -615,7 +615,7 @@ namespace Server.Items
         }
     }
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     public class JesterShoes : BaseShoes
     {
         public override int LabelNumber { get { return 1109617; } } // Jester Shoes

--- a/Scripts/Mobiles/Bosses/PrimevalLich.cs
+++ b/Scripts/Mobiles/Bosses/PrimevalLich.cs
@@ -382,40 +382,40 @@ namespace Server.Mobiles
         {
             if (Utility.RandomDouble() < 0.9 && !m_UnholyTouched.ContainsKey(target))
             {
-                int scalar = (int)(20 - (target.Skills[SkillName.MagicResist].Value / 10));
+                double scalar = -((20 - (target.Skills[SkillName.MagicResist].Value / 10)) / 100);
 
                 ArrayList mods = new ArrayList();
 
                 if (target.PhysicalResistance > 0)
                 {
-                    mods.Add(new ResistanceMod(ResistanceType.Physical, -(target.PhysicalResistance - scalar)));
+                    mods.Add(new ResistanceMod(ResistanceType.Physical, (int)((double)target.PhysicalResistance * scalar)));
                 }
 
                 if (target.FireResistance > 0)
                 {
-                    mods.Add(new ResistanceMod(ResistanceType.Fire, -(target.FireResistance - scalar)));
+                    mods.Add(new ResistanceMod(ResistanceType.Fire, (int)((double)target.FireResistance * scalar)));
                 }
 
                 if (target.ColdResistance > 0)
                 {
-                    mods.Add(new ResistanceMod(ResistanceType.Cold, -(target.ColdResistance - scalar)));
+                    mods.Add(new ResistanceMod(ResistanceType.Cold, (int)((double)target.ColdResistance * scalar)));
                 }
 
                 if (target.PoisonResistance > 0)
                 {
-                    mods.Add(new ResistanceMod(ResistanceType.Poison, -(target.PoisonResistance - scalar)));
+                    mods.Add(new ResistanceMod(ResistanceType.Poison, (int)((double)target.PoisonResistance * scalar)));
                 }
 
                 if (target.EnergyResistance > 0)
                 {
-                    mods.Add(new ResistanceMod(ResistanceType.Energy, -(target.EnergyResistance - scalar)));
+                    mods.Add(new ResistanceMod(ResistanceType.Energy, (int)((double)target.EnergyResistance * scalar)));
                 }
 
                 for (int i = 0; i < target.Skills.Length; ++i)
                 {
                     if (target.Skills[i].Value > 0)
                     {
-                        mods.Add(new DefaultSkillMod((SkillName)i, true, -(target.Skills[i].Value - scalar)));                        
+                        mods.Add(new DefaultSkillMod((SkillName)i, true, target.Skills[i].Value * scalar));
                     }
                 }
                 

--- a/Scripts/Mobiles/Normal/OrcBrute.cs
+++ b/Scripts/Mobiles/Normal/OrcBrute.cs
@@ -134,12 +134,16 @@ namespace Server.Mobiles
             }
         }
 
-        public override void OnDamagedBySpell(Mobile caster)
+        public override int Damage(int amount, Mobile from, bool informMount, bool checkDisrupt)
         {
-            if (caster == this || Controlled || Summoned)
-                return;
+            var damage = base.Damage(amount, from, informMount, checkDisrupt);
 
-            SpawnOrcLord(caster);
+            if (from != this && !Controlled && !Summoned && Utility.RandomDouble() <= 0.2)
+            {
+                SpawnOrcLord(from);
+            }
+
+            return damage;
         }
 
         public void SpawnOrcLord(Mobile target)

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -5831,9 +5831,17 @@ namespace Server.Mobiles
                 }
             }
         }
+
+        public override void OnAfterNameChange(string oldName, string newName)
+        {
+            if (m_FameKarmaTitle != null)
+            {
+                FameKarmaTitle = FameKarmaTitle.Replace(oldName, newName);
+            }
+        }
         #endregion
 
-		public override void OnKillsChange(int oldValue)
+        public override void OnKillsChange(int oldValue)
 		{
 			if (Young && Kills > oldValue)
 			{

--- a/Scripts/Services/Craft/Core/AlterItem.cs
+++ b/Scripts/Services/Craft/Core/AlterItem.cs
@@ -1,10 +1,12 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
+
+using System;
 using Server.Engines.Craft;
 using Server.Items;
 using Server.Targeting;
 using Server.Engines.VeteranRewards;
-using System.Linq;
+using Server.SkillHandlers;
 
 namespace Server.Engines.Craft
 {
@@ -297,6 +299,8 @@ namespace Server.Engines.Craft
                         newitem.Name = Server.Engines.VendorSearching.VendorSearch.StringList.GetString(origItem.LabelNumber);
                 }
 
+                AlterResists(newitem, origItem);
+
                 newitem.Hue = origItem.Hue;
                 newitem.LootType = origItem.LootType;
                 newitem.Insured = origItem.Insured;
@@ -333,9 +337,26 @@ namespace Server.Engines.Craft
                 from.SendLocalizedMessage(number);
         }
 
+        private void AlterResists(Item newItem, Item oldItem)
+        {
+            if (newItem is BaseArmor || newItem is BaseClothing)
+            {
+                var newResists = Imbuing.GetBaseResists(newItem);
+                var oldResists = Imbuing.GetBaseResists(oldItem);
+
+                for (int i = 0; i < newResists.Length; i++)
+                {
+                    if (oldResists[i] > newResists[i])
+                    {
+                        Imbuing.SetProperty(newItem, 51 + i, oldResists[i] - newResists[i]);
+                    }
+                }
+            }
+        }
+
         private bool RetainsName(Item item)
         {
-            if (item is Glasses || item is ElvenGlasses)
+            if (item is Glasses || item is ElvenGlasses || item.IsArtifact)
                 return true;
 
             if (item is IArtifact && ((IArtifact)item).ArtifactRarity > 0)

--- a/Scripts/Services/Expansions/High Seas/Items/Fish/FishInfo.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Fish/FishInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -261,7 +261,8 @@ namespace Server.Items
             //insertion of baited type first to increase chances of fishing it up!
             List<FishInfo> infos = new List<FishInfo>(m_FishInfos);
 
-            if (bait != null) {
+            if (bait != null)
+            {
                 for (int i = 0; i < infos.Count; i++)
                 {
                     FishInfo info = infos[i];
@@ -301,8 +302,10 @@ namespace Server.Items
                     if (loc.ToLower() == "trammelandfelucca" && (map == Map.Trammel || map == Map.Felucca) && !Server.Spells.SpellHelper.IsAnyT2A(map, fromLoc) && info.Roll(from, baitStr, bump))
                         item = info.Type;
 
-                    if (loc.ToLower() == "fire island" && (map == Map.Felucca || map == Map.Trammel) && (from.X > 4559 && from.X < 4636 && from.Y > 3548 && from.Y < 3627
-                        || from.X > 4465 && from.X < 4493 && from.Y > 4479 && from.Y < 3746) && info.Roll(from, baitStr, bump))
+                    if (loc.ToLower() == "fire island" && IsFireIsland(fromLoc, map) && info.Roll(from, baitStr, bump))
+                        item = info.Type;
+
+                    if (loc.ToLower() == "gravewater lake" && IsGravewaterLake(fromLoc, map))
                         item = info.Type;
 
                     if (from.Region != null && from.Region.IsPartOf(loc) && info.Roll(from, baitStr, bump))
@@ -421,6 +424,17 @@ namespace Server.Items
             if (region.IsPartOf("Labyrinth"))
                 return true;
             return false;
+        }
+
+        public static bool IsFireIsland(Point3D p, Map map)
+        {
+            return (map == Map.Felucca || map == Map.Trammel) && (p.X > 4559 && p.X < 4636 && p.Y > 3548 && p.Y < 3627
+                        || p.X > 4465 && p.X < 4493 && p.Y > 4479 && p.Y < 3746);
+        }
+
+        public static bool IsGravewaterLake(Point3D p, Map map)
+        {
+            return map == Map.Malas && ((p.X >= 1440 && p.X <= 1863 && p.Y >= 1527 && p.Y <= 1746) || (p.X >= 1381 && p.X <= 1596 && p.Y >= 1565 && p.Y <= 1789));
         }
 
         public static Type[] SOSArtifacts { get { return m_SOSArtifacts; } }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -111,6 +111,8 @@ namespace Server.Engines.Shadowguard
 
             Fame = 15000;
             Karma = -15000;
+
+            BlockReflect = true;
         }
 
         public override void GenerateLoot()
@@ -132,6 +134,8 @@ namespace Server.Engines.Shadowguard
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            BlockReflect = true;
         }
     }
 

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -89,13 +89,13 @@ namespace Server.Mobiles
             AddHtml(180, 128, 75, 18, FormatAttributes(Creature.Mana, Creature.ManaMax), false, false);
 
             AddHtmlLocalized(53, 146, 160, 18, 1028335, _Label, false, false); // Strength
-            AddHtml(180, 146, 75, 18, FormatStat(Creature.RawStr), false, false);
+            AddHtml(180, 146, 75, 18, FormatStat(Creature.Str), false, false);
 
             AddHtmlLocalized(53, 164, 160, 18, 3000113, _Label, false, false); // Dexterity
-            AddHtml(180, 164, 75, 18, FormatStat(Creature.RawDex), false, false);
+            AddHtml(180, 164, 75, 18, FormatStat(Creature.Dex), false, false);
 
             AddHtmlLocalized(53, 182, 160, 18, 3000112, _Label, false, false); // Intelligence
-            AddHtml(180, 182, 75, 18, FormatStat(Creature.RawInt), false, false);
+            AddHtml(180, 182, 75, 18, FormatStat(Creature.Int), false, false);
 
             double bd = Items.BaseInstrument.GetBaseDifficulty(Creature);
 

--- a/Scripts/Services/TreasureMaps/TreasureMap.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMap.cs
@@ -573,10 +573,6 @@ namespace Server.Items
             x2 = x1 + width;
             y2 = y1 + height;
 
-            if (eodon)
-            {
-            }
-
             if (map == Map.Trammel || map == Map.Felucca)
             {
                 if (x2 >= 5120)

--- a/Scripts/Services/Vendor Searching/VendorSearchMap.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchMap.cs
@@ -61,8 +61,9 @@ namespace Server.Items
 
             Width = 300;
             Height = 300;
+            var size = item.Map == Map.Tokuno ? 300 : item.Map == Map.TerMur ? 200 : 600;
 
-            Bounds = new Rectangle2D(p.X - 300, p.Y - 300, 600, 600);
+            Bounds = new Rectangle2D(p.X - size / 2, p.Y - size / 2, size, size);
             AddWorldPin(p.X, p.Y);            
 
             DeleteTime = DateTime.UtcNow + TimeSpan.FromMinutes(DeleteDelayMinutes);

--- a/Scripts/Spells/Ninjitsu/DeathStrike.cs
+++ b/Scripts/Spells/Ninjitsu/DeathStrike.cs
@@ -59,10 +59,7 @@ namespace Server.Spells.Ninjitsu
             double ninjitsu = attacker.Skills[SkillName.Ninjitsu].Value;
 
             double chance;
-            bool isRanged = false; // should be defined onHit method, what if the player hit and remove the weapon before process? ;)
-
-            if (attacker.Weapon is BaseRanged)
-                isRanged = true;
+            bool isRanged = attacker.Weapon is BaseRanged;
 
             if (ninjitsu < 100) //This formula is an approximation from OSI data.  TODO: find correct formula
                 chance = 30 + (ninjitsu - 85) * 2.2;

--- a/Scripts/Spells/Skill Masteries/NetherBlast.cs
+++ b/Scripts/Spells/Skill Masteries/NetherBlast.cs
@@ -24,6 +24,7 @@ namespace Server.Spells.SkillMasteries
         public override double UpKeep { get { return 0; } }
         public override int RequiredMana { get { return 40; } }
         public override bool PartyEffects { get { return false; } }
+        public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(2.0); } }
 
         public override SkillName CastSkill { get { return SkillName.Mysticism; } }
         public override SkillName DamageSkill

--- a/Scripts/Spells/Spellweaving/ArcaneEmpowerment.cs
+++ b/Scripts/Spells/Spellweaving/ArcaneEmpowerment.cs
@@ -97,6 +97,8 @@ namespace Server.Spells.Spellweaving
                 m_Table[Caster] = new EmpowermentInfo(Caster, duration, bonus, level);
 
                 BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.ArcaneEmpowerment, 1031616, 1075808, duration, Caster, new TextDefinition(String.Format("{0}\t10", bonus.ToString()))));
+
+                Caster.Delta(MobileDelta.WeaponDamage);
             }
 
             FinishSequence();
@@ -131,6 +133,8 @@ namespace Server.Spells.Spellweaving
             {
                 m_Mobile.PlaySound(0x5C2);
                 m_Table.Remove(m_Mobile);
+
+                m_Mobile.Delta(MobileDelta.WeaponDamage);
             }
         }
     }

--- a/Scripts/Spells/Spellweaving/Wildfire.cs
+++ b/Scripts/Spells/Spellweaving/Wildfire.cs
@@ -201,7 +201,7 @@ namespace Server.Spells.Spellweaving
             {
                 WildfireSpell.DefragTable();
 
-                return m_Spell.AcquireIndirectTargets(m_Location, m_Range).OfType<Mobile>();
+                return m_Spell.AcquireIndirectTargets(m_Location, m_Range).OfType<Mobile>().Where(m => !m_Table.ContainsKey(m));
             }			
         }
 


### PR DESCRIPTION
* - Internal Galleon Update: Galleon Facing now  uses the Multi Component List to change the ID's of fixtures. Some of the ID's (weapon pads) were not using the correct ID's, and this way the code is much more simplified. All fixture lists have been consolidated into one list.
- Gargish Jewels no longer drop on non-SA Core
- Fixed issue with trapped boxes
- Added Event Sink for sending detailed house foundation packet.
- Fixed issue where imbued jewelry weren't getting durability.

* update solution
fixed graphical issue

* Bug Fixes
- Added Blackthorne DUngeon stealables
- Added proper base resists to Leather Ninja Hood
- Medusa now drops Medusa Floor Tile Addon Deed (THANKS MILVA!)
- AOSWeaponAttributes now work on Armor
- Protection now expires after player death
- Fixed crash in PVP Arena Gumps
- Exceptional Damage Inc no longer gives extra points for Clean up Britannia Turn In
- Fixed Loyalty Gump Crash
- Fixed Stygian Dragon arty drops per EA

* Potential Crash Fix

* csproj update

* Fixed conflict issue... WTF?

* Bug Fixes *Requires Core Recompile*
- Fixed cliloc on new belt craftables
- failed craft no longer deletes crimson cincture and luck mempo
- Added a core edit to Container.cs (had to do it folks) for better resource evaluation when considering resources to consume while crafting. In this instance, we don't want VvV or Faction items being used as craftable resources due to thier ease of obtaining.
- Consolidated no-delete resources in CraftSystem.cs
- Fellowship Data now serializes to prevent generation at each server start

* Resolve Conflicts

* Bug Fixes
- Shield bash forumula no more EA like (still not perfect)
- Healers now show to dead players (needs work)
- Honor buff now persists through death
-

* crash fix

* Initial Commit - Publish 105 Forgotten Treasures
- Removed Remove trap skill prerequisites

* Moongate Fix
- You have to be 1 tile to double click it. All other range checks are correct.

* Commit #2

* crash fix

* Commit #3

* Crash Fix

* Commit #3

* More updates and additions. Compiles!

* Final Commit

* Project Update

* Shields no longer engraveable w/ armor engraving tool.

* Fixed THunting Town Crier Quest
Fixed issue where initial guardians were not spawning for level 1 maps

* Compile error fix.

* COmpire error #2 fix

* Bug Fixes
- Summoners Kilt is now repairable
- Orange petals are now 1 stone each (HS era check)
- Enabled altering artifact (IsArtifact) footwear
- Altering certain artifact (IsArtifact) items now carry over the proper resistance bonuses
- Fixed Primeval Lich Unholy Touch special ability
- Orc brutes now have a chance to throw an orc on any damage Received
- Name changes now show up on the paperdoll (you have to close/re-open)
- Removed "Gravewater Lake" region. It was conflicting with region functionality in Exploring the Deep Quest
- Shadowguard Orchard Encounter apples now spawn a treefellow on each player in the region when deleted and thrown at the incorrect Tree
- Shanty the Pirate no longer does reflect damage attack
- Animal Lore gump now shows adjusted stats, ie cursed/blessed
- Vendor Maps in Tokuno no longer crash the client
- Nether Blase cast delay moved to 2.0 seconds, per EA
- Arcane Empowerment SDI buff now shows in the status bar
- Wildfire should no longer stack