### PR TITLE
Bug Fixes (#4588)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /Scripts/bin
 /Scripts/obj
 /Scripts/Output
-/Scripts/Custom
 
 /Honesty
 /Logs

--- a/Scripts/Abilities/WeaponAbility.cs
+++ b/Scripts/Abilities/WeaponAbility.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
+
 using Server.Network;
 using Server.Spells;
+using Server.Spells.SkillMasteries;
 
 namespace Server.Items
 {
@@ -459,6 +461,8 @@ namespace Server.Items
                 SpecialMove.ClearCurrentMove(m);
 
                 m_Table[m] = a;
+
+                SkillMasterySpell.CancelWeaponAbility(m);
             }
 
             return true;

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1643,7 +1643,7 @@ namespace Server.Items
 
 			SpecialMove move = SpecialMove.GetCurrentMove(attacker);
 
-            if (move != null && (!move.OnBeforeSwing(attacker, defender) || SkillMasterySpell.CancelSpecialMove(attacker)))
+            if (move != null && !move.OnBeforeSwing(attacker, defender))
             {
                 SpecialMove.ClearCurrentMove(attacker);
             }

--- a/Scripts/Items/Functional/PublicMoongate.cs
+++ b/Scripts/Items/Functional/PublicMoongate.cs
@@ -116,7 +116,7 @@ namespace Server.Items
 			}
 		}
 		
-		public override int LabelNumber {get {return 1076082;} } // Moongate
+		public override int LabelNumber {get {return 1023952;} } // Blue Moongate
 
 		public override bool HandlesOnMovement { get { return true; } }
 		public override bool ForceShowProperties { get { return true; } }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6563,6 +6563,12 @@ namespace Server.Mobiles
             {
                 m.InvalidateProperties();
             }
+
+            if (_NavPoints != null)
+            {
+                _NavPoints.Clear();
+                _NavPoints = null;
+            }
         }
 
         public override bool CanBeHarmful(IDamageable damageable, bool message, bool ignoreOurBlessedness)

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -1302,9 +1302,11 @@ namespace Server.Multis
                     return true;
             }
 
-            if (tiles.Length == 0 && this is Castle)
-                return true;
+            return IsInsideSpecial(p, tiles);
+        }
 
+        protected virtual bool IsInsideSpecial(Point3D p, StaticTile[] tiles)
+        {
             return false;
         }
 

--- a/Scripts/Multis/Houses.cs
+++ b/Scripts/Multis/Houses.cs
@@ -406,6 +406,12 @@ namespace Server.Multis
                 return new Point3D(5, 17, 0);
             }
         }
+
+        protected override bool IsInsideSpecial(Point3D p, StaticTile[] tiles)
+        {
+            return p.X >= X - 10 && p.X <= X + 10 && p.Y >= Y - 10 && p.Y <= Y + 10;
+        }
+
         public override HouseDeed GetDeed()
         {
             return new CastleDeed();

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -65,8 +65,13 @@ namespace Server.Regions
         {
             Item item = e as Item;
 
-            if (m.PublicHouseContent && House.Public || House.IsInside(m) || ExcludeItem(item) || m.InHouseCanSee(item.RootParent))
+            if ((m.PublicHouseContent && House.Public) ||
+                    House.IsInside(m) ||
+                    ExcludeItem(item) ||
+                    (item.RootParent != null && m.CanSee(item.RootParent)))
+            {
                 return true;
+            }
 
             return false;
         }

--- a/Scripts/Services/Assistants.cs
+++ b/Scripts/Services/Assistants.cs
@@ -1,4 +1,4 @@
-﻿#region References
+#region References
 using System;
 using System.Collections.Generic;
 
@@ -125,13 +125,14 @@ namespace Server.Misc
 				EventSink.Login += e =>
 				{
 					Mobile m = e.Mobile;
+                    NetState ns = m.NetState;
 
-					if (m == null || m.NetState == null || !m.NetState.Running)
-					{
-						return;
-					}
+                    if (m == null || ns == null || !ns.Running || ns.IsEnhancedClient)
+                    {
+                        return;
+                    }
 
-					m.Send(new BeginHandshake());
+                    m.Send(new BeginHandshake());
 
 					if (_Dictionary.ContainsKey(m))
 					{

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -294,6 +294,7 @@ namespace Server.Mobiles
         public static AreaEffect[] AreaEffectArea2;
         public static AreaEffect[] AreaEffectArea3;
         public static AreaEffect[] AreaEffectArea4;
+        public static AreaEffect[] AreaEffectArea5;
         #endregion
 
         #region Weapon Ability Defs
@@ -669,6 +670,11 @@ namespace Server.Mobiles
                 AreaEffect.AuraOfEnergy, AreaEffect.ExplosiveGoo, AreaEffect.AuraOfNausea,
                 AreaEffect.PoisonBreath, AreaEffect.EssenceOfDisease,                
             };
+
+            AreaEffectArea5 = new AreaEffect[]
+            {
+                AreaEffect.ExplosiveGoo, AreaEffect.AuraOfNausea,  AreaEffect.PoisonBreath, AreaEffect.EssenceOfDisease
+            };
             #endregion
 
             #region Creature Training Defs
@@ -709,7 +715,7 @@ namespace Server.Mobiles
                 new TrainingDefinition(typeof(DreadWarhorse), Class.MagicalAndNecromantic, MagicalAbility.DreadWarhorse, new SpecialAbility[] { SpecialAbility.DragonBreath }, WepAbility2, AreaEffectArea2, 3, 5), 
                 new TrainingDefinition(typeof(Eagle), Class.Clawed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawed, WepAbility1, AreaEffectNone, 1, 3), 
                 new TrainingDefinition(typeof(Ferret), Class.Clawed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawed, WepAbility1, AreaEffectNone, 1, 2), 
-                new TrainingDefinition(typeof(FireBeetle), Class.MagicalAndInsectoid, MagicalAbility.StandardClawedOrTailed, SpecialAbilityMagicalInsectoid, WepAbility1, AreaEffectExplosiveGoo, 1 ,5),
+                new TrainingDefinition(typeof(FireBeetle), Class.MagicalAndInsectoid, MagicalAbility.StandardClawedOrTailed, SpecialAbilityMagicalInsectoid, WepAbility1, AreaEffectArea5, 1 ,5),
                 new TrainingDefinition(typeof(FireSteed), Class.Magical, MagicalAbility.Dragon2, SpecialAbilityNone, WepAbility2, AreaEffectArea1, 2, 5),
                 new TrainingDefinition(typeof(ForestOstard), Class.Clawed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawed, WepAbility1, AreaEffectNone, 1, 3),
                 new TrainingDefinition(typeof(FrenziedOstard), Class.Clawed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawed, WepAbility1, AreaEffectNone, 1, 3),

--- a/Scripts/Spells/Base/SpecialMove.cs
+++ b/Scripts/Spells/Base/SpecialMove.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+
 using Server.Items;
 using Server.Network;
 using Server.Spells.Bushido;
 using Server.Spells.Ninjitsu;
+using Server.Spells.SkillMasteries;
 
 namespace Server.Spells
 {
@@ -305,9 +307,9 @@ namespace Server.Spells
                 if (moveID > 0)
                     m.Send(new ToggleSpecialAbility(moveID + 1, true));
 
-                Server.Spells.SkillMasteries.SkillMasterySpell.OnToggleSpecialAbility(m);
-
                 move.SendAbilityMessage(m);
+
+                SkillMasterySpell.CancelSpecialMove(m);
             }
 
             return true;

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -41,7 +41,6 @@ namespace Server.Spells.SkillMasteries
 
         public virtual bool CancelsWeaponAbility { get { return false; } }
         public virtual bool CancelsSpecialMove { get { return CancelsWeaponAbility; } }
-        public virtual bool ClearOnSpecialAbility { get { return false; } }
 
         public virtual bool RevealOnTick { get { return true; } }
 
@@ -979,41 +978,19 @@ namespace Server.Spells.SkillMasteries
             }
         }
 
-        public static bool CancelWeaponAbility(Mobile attacker)
+        public static void CancelWeaponAbility(Mobile attacker)
         {
-            foreach (SkillMasterySpell spell in EnumerateSpells(attacker))
+            foreach (SkillMasterySpell spell in EnumerateSpells(attacker).Where(s => s.CancelsWeaponAbility))
             {
-                if (spell.CancelsWeaponAbility)
-                    return true;
+                spell.Expire();
             }
-
-            return false;
         }
 
-        public static bool CancelSpecialMove(Mobile attacker)
+        public static void CancelSpecialMove(Mobile attacker)
         {
-            foreach (SkillMasterySpell spell in EnumerateSpells(attacker))
+            foreach (SkillMasterySpell spell in EnumerateSpells(attacker).Where(s => s.CancelsSpecialMove))
             {
-                if (spell.CancelsSpecialMove)
-                    return true;
-            }
-
-            return false;
-        }
-
-        public static void OnToggleSpecialAbility(Mobile m)
-        {
-            CheckTable(m);
-
-            if (m_Table.ContainsKey(m))
-            {
-                foreach (SkillMasterySpell sp in EnumerateSpells(m))
-                {
-                    if (sp.ClearOnSpecialAbility)
-                    {
-                        sp.Expire(true);
-                    }
-                }
+                spell.Expire();
             }
         }
 

--- a/Scripts/Spells/Skill Masteries/InjectedStrike.cs
+++ b/Scripts/Spells/Skill Masteries/InjectedStrike.cs
@@ -21,7 +21,6 @@ namespace Server.Spells.SkillMasteries
         public override SkillName CastSkill { get { return SkillName.Poisoning; } }
 		public override SkillName DamageSkill { get { return SkillName.Anatomy; } }
 
-        public override bool ClearOnSpecialAbility { get { return true; } }
         public override bool CancelsWeaponAbility { get { return true; } }
 
         public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(1.0); } }

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -9163,22 +9163,6 @@ namespace Server
 			}
 		}
 
-        public virtual bool InHouseCanSee(object o)
-        {
-            if (o is Item)
-            {
-                return CanSee((Item)o);
-            }
-            else if (o is Mobile)
-            {
-                return CanSee((Mobile)o);
-            }
-            else
-            {
-                return false;
-            }
-        }
-
         public virtual bool CanSee(Item item)
 		{
 			if (m_Map == Map.Internal)


### PR DESCRIPTION
* - Internal Galleon Update: Galleon Facing now  uses the Multi Component List to change the ID's of fixtures. Some of the ID's (weapon pads) were not using the correct ID's, and this way the code is much more simplified. All fixture lists have been consolidated into one list.
- Gargish Jewels no longer drop on non-SA Core
- Fixed issue with trapped boxes
- Added Event Sink for sending detailed house foundation packet.
- Fixed issue where imbued jewelry weren't getting durability.

* update solution
fixed graphical issue

* Bug Fixes
- Added Blackthorne DUngeon stealables
- Added proper base resists to Leather Ninja Hood
- Medusa now drops Medusa Floor Tile Addon Deed (THANKS MILVA!)
- AOSWeaponAttributes now work on Armor
- Protection now expires after player death
- Fixed crash in PVP Arena Gumps
- Exceptional Damage Inc no longer gives extra points for Clean up Britannia Turn In
- Fixed Loyalty Gump Crash
- Fixed Stygian Dragon arty drops per EA

* Potential Crash Fix

* csproj update

* Fixed conflict issue... WTF?

* Bug Fixes *Requires Core Recompile*
- Fixed cliloc on new belt craftables
- failed craft no longer deletes crimson cincture and luck mempo
- Added a core edit to Container.cs (had to do it folks) for better resource evaluation when considering resources to consume while crafting. In this instance, we don't want VvV or Faction items being used as craftable resources due to thier ease of obtaining.
- Consolidated no-delete resources in CraftSystem.cs
- Fellowship Data now serializes to prevent generation at each server start

* Resolve Conflicts

* Bug Fixes
- Shield bash forumula no more EA like (still not perfect)
- Healers now show to dead players (needs work)
- Honor buff now persists through death
-

* crash fix

* Initial Commit - Publish 105 Forgotten Treasures
- Removed Remove trap skill prerequisites

* Moongate Fix
- You have to be 1 tile to double click it. All other range checks are correct.

* Commit #2

* crash fix

* Commit #3

* Crash Fix

* Commit #3

* More updates and additions. Compiles!

* Final Commit

* Project Update

* Shields no longer engraveable w/ armor engraving tool.

* Fixed THunting Town Crier Quest
Fixed issue where initial guardians were not spawning for level 1 maps

* Compile error fix.

* COmpire error #2 fix

* Bug Fixes
- Summoners Kilt is now repairable
- Orange petals are now 1 stone each (HS era check)
- Enabled altering artifact (IsArtifact) footwear
- Altering certain artifact (IsArtifact) items now carry over the proper resistance bonuses
- Fixed Primeval Lich Unholy Touch special ability
- Orc brutes now have a chance to throw an orc on any damage Received
- Name changes now show up on the paperdoll (you have to close/re-open)
- Removed "Gravewater Lake" region. It was conflicting with region functionality in Exploring the Deep Quest
- Shadowguard Orchard Encounter apples now spawn a treefellow on each player in the region when deleted and thrown at the incorrect Tree
- Shanty the Pirate no longer does reflect damage attack
- Animal Lore gump now shows adjusted stats, ie cursed/blessed
- Vendor Maps in Tokuno no longer crash the client
- Nether Blase cast delay moved to 2.0 seconds, per EA
- Arcane Empowerment SDI buff now shows in the status bar
- Wildfire should no longer stack

* Bug Fixes
- Toggling weapon specials now expires Injected Strike
- Crafting stacked items will now drastically reduce the amount of skill gains, per EA
- Fixed issue where items were invisible to players in castle courtyards
- Fixed issue where Assistants were kicking EC clients during Handshake
- Added proper area effects to Fire Beetle

* Added singing ball