### PR TITLE
Bug Fixes (#4590)

### DIFF
--- a/Scripts/Abilities/FrenziedWhirlwind.cs
+++ b/Scripts/Abilities/FrenziedWhirlwind.cs
@@ -134,11 +134,10 @@ namespace Server.Items
                         int skill = m_Attacker is BaseCreature ? (int)m_Attacker.Skills[SkillName.Ninjitsu].Value :
                                                               (int)Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value);
 
-                        int amount = Utility.RandomMinMax((int)(skill / 50) * 5, (int)(skill / 50) * 20) + 2;
-                        AOS.Damage(m, m_Attacker, amount, 100, 0, 0, 0, 0);
+                        var baseMin = (int)Math.Max(5, (skill / 50) * 5);
 
-                        //m_Attacker.SendLocalizedMessage(1060161); // The whirling attack strikes a target!
-                        //m_Defender.SendLocalizedMessage(1060162); // You are struck by the whirling attack and take damage!
+                        int amount = Utility.RandomMinMax(baseMin, (baseMin  * 20) + 2);
+                        AOS.Damage(m, m_Attacker, amount, 100, 0, 0, 0, 0);
                     }
                 }
             }

--- a/Scripts/Mobiles/NPCs/Thief.cs
+++ b/Scripts/Mobiles/NPCs/Thief.cs
@@ -16,6 +16,7 @@ namespace Server.Mobiles
             SetSkill(SkillName.Archery, 65.0, 88.0);
             SetSkill(SkillName.Tracking, 65.0, 88.0);
             SetSkill(SkillName.Veterinary, 60.0, 83.0);
+            SetSkill(SkillName.RemoveTrap, 75.0, 98.0);
         }
 
         public Thief(Serial serial)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4246,7 +4246,7 @@ namespace Server.Mobiles
                 return false;
             }
 
-            if (skill == SkillName.RemoveTrap &&
+            if (!Core.EJ && skill == SkillName.RemoveTrap &&
                 (from.Skills[SkillName.Lockpicking].Base < 50.0 || from.Skills[SkillName.DetectHidden].Base < 50.0))
             {
                 return false;

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -555,6 +555,16 @@ namespace Server.Spells.SkillMasteries
             return null;
         }
 
+        public static TSpell GetSpell<TSpell>(Mobile caster, Mobile target) where TSpell : SkillMasterySpell
+        {
+            if (m_Table.ContainsKey(caster))
+            {
+                return m_Table[caster].FirstOrDefault(sms => sms.GetType() == typeof(TSpell) && sms.Target == target) as TSpell;
+            }
+
+            return null;
+        }
+
         public static SkillMasterySpell GetSpell(Func<SkillMasterySpell, bool> predicate)
 		{
             foreach (SkillMasterySpell spell in EnumerateAllSpells())

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -57,7 +57,11 @@ namespace Server.Spells.SkillMasteries
 
             if (m != null)
             {
-                if (CheckHSequence(m))
+                if (GetSpell<DeathRaySpell>(Caster, m) != null)
+                {
+                    Caster.SendLocalizedMessage(1156094); // Your target is already under the effect of this ability.
+                }
+                else if (CheckHSequence(m))
                 {
                     if (CheckResisted(m))
                     {
@@ -67,11 +71,6 @@ namespace Server.Spells.SkillMasteries
                     else
                     {
                         SpellHelper.CheckReflect(0, Caster, ref m);
-                        SkillMasterySpell spell = GetSpell(Caster, this.GetType());
-
-                        if (spell != null && spell.Target == m)
-                            spell.Expire();
-
                         _Location = Caster.Location;
 
                         m.FixedParticles(0x374A, 1, 15, 5054, 0x7A2, 7, EffectLayer.Head);


### PR DESCRIPTION
* - Internal Galleon Update: Galleon Facing now  uses the Multi Component List to change the ID's of fixtures. Some of the ID's (weapon pads) were not using the correct ID's, and this way the code is much more simplified. All fixture lists have been consolidated into one list.
- Gargish Jewels no longer drop on non-SA Core
- Fixed issue with trapped boxes
- Added Event Sink for sending detailed house foundation packet.
- Fixed issue where imbued jewelry weren't getting durability.

* update solution
fixed graphical issue

* Bug Fixes
- Added Blackthorne DUngeon stealables
- Added proper base resists to Leather Ninja Hood
- Medusa now drops Medusa Floor Tile Addon Deed (THANKS MILVA!)
- AOSWeaponAttributes now work on Armor
- Protection now expires after player death
- Fixed crash in PVP Arena Gumps
- Exceptional Damage Inc no longer gives extra points for Clean up Britannia Turn In
- Fixed Loyalty Gump Crash
- Fixed Stygian Dragon arty drops per EA

* Potential Crash Fix

* csproj update

* Fixed conflict issue... WTF?

* Bug Fixes *Requires Core Recompile*
- Fixed cliloc on new belt craftables
- failed craft no longer deletes crimson cincture and luck mempo
- Added a core edit to Container.cs (had to do it folks) for better resource evaluation when considering resources to consume while crafting. In this instance, we don't want VvV or Faction items being used as craftable resources due to thier ease of obtaining.
- Consolidated no-delete resources in CraftSystem.cs
- Fellowship Data now serializes to prevent generation at each server start

* Resolve Conflicts

* Bug Fixes
- Shield bash forumula no more EA like (still not perfect)
- Healers now show to dead players (needs work)
- Honor buff now persists through death
-

* crash fix

* Initial Commit - Publish 105 Forgotten Treasures
- Removed Remove trap skill prerequisites

* Moongate Fix
- You have to be 1 tile to double click it. All other range checks are correct.

* Commit #2

* crash fix

* Commit #3

* Crash Fix

* Commit #3

* More updates and additions. Compiles!

* Final Commit

* Project Update

* Shields no longer engraveable w/ armor engraving tool.

* Fixed THunting Town Crier Quest
Fixed issue where initial guardians were not spawning for level 1 maps

* Compile error fix.

* COmpire error #2 fix

* Bug Fixes
- Summoners Kilt is now repairable
- Orange petals are now 1 stone each (HS era check)
- Enabled altering artifact (IsArtifact) footwear
- Altering certain artifact (IsArtifact) items now carry over the proper resistance bonuses
- Fixed Primeval Lich Unholy Touch special ability
- Orc brutes now have a chance to throw an orc on any damage Received
- Name changes now show up on the paperdoll (you have to close/re-open)
- Removed "Gravewater Lake" region. It was conflicting with region functionality in Exploring the Deep Quest
- Shadowguard Orchard Encounter apples now spawn a treefellow on each player in the region when deleted and thrown at the incorrect Tree
- Shanty the Pirate no longer does reflect damage attack
- Animal Lore gump now shows adjusted stats, ie cursed/blessed
- Vendor Maps in Tokuno no longer crash the client
- Nether Blase cast delay moved to 2.0 seconds, per EA
- Arcane Empowerment SDI buff now shows in the status bar
- Wildfire should no longer stack

* Bug Fixes
- Toggling weapon specials now expires Injected Strike
- Crafting stacked items will now drastically reduce the amount of skill gains, per EA
- Fixed issue where items were invisible to players in castle courtyards
- Fixed issue where Assistants were kicking EC clients during Handshake
- Added proper area effects to Fire Beetle

* Added singing ball

* Bug Fixes
- Increases Spinning Wheel timer to 6s
- Attacking pets now use active speed when combatant is not a player, per EA
- Fixed name issue for certain CUB pigments
- Fixed issue where only young players could use stash treasure maps
- Blackthorn invasion creatures will no longer be able to swim (water elementals)

* Bug Fixes
- Adjusted Frenzied Whirlwind min damage
- Thiefs now train remove trap
- Training remove trap no longer requires lockpicking and detect hidden
- Death ray can no longer be stacked on single targets

* Removed unused code

* More adjustments.