### PR TITLE
Bug Fixes (#4596)

### DIFF
--- a/Scripts/Items/Consumables/EodonPotions.cs
+++ b/Scripts/Items/Consumables/EodonPotions.cs
@@ -249,10 +249,14 @@ namespace Server.Items
 
                 foreach (var kvp in dictionary)
                 {
-                    foreach (var context in kvp.Value)
+                    var contexts = new List<EodonPotionContext>(kvp.Value);
+
+                    foreach (var context in contexts)
                     {
                         context.OnTick(kvp.Key);
                     }
+
+                    ColUtility.Free(contexts);
                 }
 
                 dictionary.Clear();

--- a/Scripts/Items/Functional/StealableArtifactsSpawner.cs
+++ b/Scripts/Items/Functional/StealableArtifactsSpawner.cs
@@ -183,9 +183,9 @@ namespace Server.Items
 	        new StealableEntry(Map.TerMur, new Point3D(1131, 1128, -42), 18432, 27648, typeof(BlockAndTackleArtifact)),
 
             //Ararat Stealables (Exploring the Deep) - Artifact rarity 8
-            new StealableEntry(Map.Trammel, new Point3D(6430, 1637, 0), 9216, 13824, typeof(SternAnchorOfBmvArarat)),
-            new StealableEntry(Map.Trammel, new Point3D(6423, 1658, 0), 9216, 13824, typeof(ShipsBellOfBmvArarat)),
-            new StealableEntry(Map.Trammel, new Point3D(6405, 1640, 0), 9216, 13824, typeof(FigureheadOfBmvArarat)),
+            new StealableEntry(Map.Trammel, new Point3D(6303, 1664, 11), 9216, 13824, typeof(SternAnchorOfBmvArarat)),
+            new StealableEntry(Map.Trammel, new Point3D(6303, 1756, 20), 9216, 13824, typeof(ShipsBellOfBmvArarat)),
+            new StealableEntry(Map.Trammel, new Point3D(6313, 1753, -14), 9216, 13824, typeof(FigureheadOfBmvArarat)),
 
             // Castle Blackthorne Stealables - Rarity 8 - does not show rarity on items
             new StealableEntry(Map.Trammel, new Point3D(6436, 2606, 11), 9216, 13824, typeof(KingsGildedStatue)),

--- a/Scripts/Multis/ComponentVerification.cs
+++ b/Scripts/Multis/ComponentVerification.cs
@@ -8,7 +8,10 @@ namespace Server.Multis
 {
 	public class ComponentVerification
 	{
-		private readonly int[] m_ItemTable;
+        public int[] ItemTable { get { return m_ItemTable; } }
+        public int[] MultiTable { get { return m_MultiTable; } }
+
+        private readonly int[] m_ItemTable;
 		private readonly int[] m_MultiTable;
 
 		public ComponentVerification()

--- a/Scripts/Services/TreasureMaps/TreasureMap.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMap.cs
@@ -1605,6 +1605,8 @@ namespace Server.Items
 
                         BaseCreature bc = Spawn(m_TreasureMap.Level, m_Chest.Location, m_Chest.Map, null, guardian);
 
+                        bc.Hue = 2725;
+
                         if (bc != null && guardian)
                         {
                             m_Chest.Guardians.Add(bc);

--- a/Scripts/Services/TreasureMaps/TreasureMapChest.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapChest.cs
@@ -591,7 +591,11 @@ namespace Server.Items
                 m_Lifted.Add(item);
 
                 if (0.1 >= Utility.RandomDouble()) // 10% chance to spawn a new monster
-                    TreasureMap.Spawn(Level, GetWorldLocation(), Map, from, false);
+                {
+                    var spawn = TreasureMap.Spawn(Level, GetWorldLocation(), Map, from, false);
+
+                    spawn.Hue = 2725;
+                }
             }
 
             base.OnItemLifted(from, item);
@@ -620,6 +624,8 @@ namespace Server.Items
                 spawn.Hits = spawn.HitsMax;
                 spawn.Mana = spawn.ManaMax;
                 spawn.Stam = spawn.StamMax;
+
+                spawn.Hue = 1960;
 
                 for (int i = 0; i < spawn.Skills.Length; i++)
                 {


### PR DESCRIPTION
* - Internal Galleon Update: Galleon Facing now  uses the Multi Component List to change the ID's of fixtures. Some of the ID's (weapon pads) were not using the correct ID's, and this way the code is much more simplified. All fixture lists have been consolidated into one list.
- Gargish Jewels no longer drop on non-SA Core
- Fixed issue with trapped boxes
- Added Event Sink for sending detailed house foundation packet.
- Fixed issue where imbued jewelry weren't getting durability.

* update solution
fixed graphical issue

* Bug Fixes
- Added Blackthorne DUngeon stealables
- Added proper base resists to Leather Ninja Hood
- Medusa now drops Medusa Floor Tile Addon Deed (THANKS MILVA!)
- AOSWeaponAttributes now work on Armor
- Protection now expires after player death
- Fixed crash in PVP Arena Gumps
- Exceptional Damage Inc no longer gives extra points for Clean up Britannia Turn In
- Fixed Loyalty Gump Crash
- Fixed Stygian Dragon arty drops per EA

* Potential Crash Fix

* csproj update

* Fixed conflict issue... WTF?

* Bug Fixes *Requires Core Recompile*
- Fixed cliloc on new belt craftables
- failed craft no longer deletes crimson cincture and luck mempo
- Added a core edit to Container.cs (had to do it folks) for better resource evaluation when considering resources to consume while crafting. In this instance, we don't want VvV or Faction items being used as craftable resources due to thier ease of obtaining.
- Consolidated no-delete resources in CraftSystem.cs
- Fellowship Data now serializes to prevent generation at each server start

* Resolve Conflicts

* Bug Fixes
- Shield bash forumula no more EA like (still not perfect)
- Healers now show to dead players (needs work)
- Honor buff now persists through death
-

* crash fix

* Initial Commit - Publish 105 Forgotten Treasures
- Removed Remove trap skill prerequisites

* Moongate Fix
- You have to be 1 tile to double click it. All other range checks are correct.

* Commit #2

* crash fix

* Commit #3

* Crash Fix

* Commit #3

* More updates and additions. Compiles!

* Final Commit

* Project Update

* Shields no longer engraveable w/ armor engraving tool.

* Fixed THunting Town Crier Quest
Fixed issue where initial guardians were not spawning for level 1 maps

* Compile error fix.

* COmpire error #2 fix

* Bug Fixes
- Summoners Kilt is now repairable
- Orange petals are now 1 stone each (HS era check)
- Enabled altering artifact (IsArtifact) footwear
- Altering certain artifact (IsArtifact) items now carry over the proper resistance bonuses
- Fixed Primeval Lich Unholy Touch special ability
- Orc brutes now have a chance to throw an orc on any damage Received
- Name changes now show up on the paperdoll (you have to close/re-open)
- Removed "Gravewater Lake" region. It was conflicting with region functionality in Exploring the Deep Quest
- Shadowguard Orchard Encounter apples now spawn a treefellow on each player in the region when deleted and thrown at the incorrect Tree
- Shanty the Pirate no longer does reflect damage attack
- Animal Lore gump now shows adjusted stats, ie cursed/blessed
- Vendor Maps in Tokuno no longer crash the client
- Nether Blase cast delay moved to 2.0 seconds, per EA
- Arcane Empowerment SDI buff now shows in the status bar
- Wildfire should no longer stack

* Bug Fixes
- Toggling weapon specials now expires Injected Strike
- Crafting stacked items will now drastically reduce the amount of skill gains, per EA
- Fixed issue where items were invisible to players in castle courtyards
- Fixed issue where Assistants were kicking EC clients during Handshake
- Added proper area effects to Fire Beetle

* Added singing ball

* Bug Fixes
- Increases Spinning Wheel timer to 6s
- Attacking pets now use active speed when combatant is not a player, per EA
- Fixed name issue for certain CUB pigments
- Fixed issue where only young players could use stash treasure maps
- Blackthorn invasion creatures will no longer be able to swim (water elementals)

* Bug Fixes
- Adjusted Frenzied Whirlwind min damage
- Thiefs now train remove trap
- Training remove trap no longer requires lockpicking and detect hidden
- Death ray can no longer be stacked on single targets

* Removed unused code

* More adjustments.

* Final Frenzied whirlwind fix

* Bug Fixes
- Treasure Maps now only spawn 1 ancient guardian at a time during remove trap
- Players can now cast spells while digging up Chest
- Removed skill wait time if chest is out of range
- Nether blast mana rip no longer works if target has no mana

* - Fixed Eodonian Potion Crash
- Fixed Ararat Artifact Spawn Locations
- Added Hues to TMap Guardians per EA